### PR TITLE
Fix drag/drop & numeric input

### DIFF
--- a/client/src/components/fit-file-upload.tsx
+++ b/client/src/components/fit-file-upload.tsx
@@ -75,7 +75,7 @@ export default function FitFileUpload() {
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(false);
-    
+
     const files = Array.from(e.dataTransfer.files);
     if (files.length > 0) {
       handleFileSelect(files[0]);
@@ -83,6 +83,12 @@ export default function FitFileUpload() {
   };
 
   const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+    setIsDragOver(true);
+  };
+
+  const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(true);
   };
@@ -136,6 +142,7 @@ export default function FitFileUpload() {
                 : "border-gray-300 hover:border-ocean-blue"
             } ${uploadMutation.isPending ? "opacity-50 pointer-events-none" : ""}`}
             onDrop={handleDrop}
+            onDragEnter={handleDragEnter}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onClick={handleClick}

--- a/client/src/components/session-form.tsx
+++ b/client/src/components/session-form.tsx
@@ -211,7 +211,11 @@ export default function SessionForm() {
                         type="number"
                         placeholder="180"
                         {...field}
-                        onChange={(e) => field.onChange(e.target.value)}
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value ? parseInt(e.target.value) : undefined
+                          )
+                        }
                       />
                     </FormControl>
                     <FormMessage />


### PR DESCRIPTION
## Summary
- allow file drop events to mark drag state and show copy effect
- fix numeric heart rate parsing to prevent validation errors

## Testing
- `npm run check` *(fails: TS errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_686c35c49d0c832ba19953db5ec0bb51