### PR TITLE
Fix FIT upload errors and form types

### DIFF
--- a/client/src/components/fit-file-upload.tsx
+++ b/client/src/components/fit-file-upload.tsx
@@ -75,7 +75,7 @@ export default function FitFileUpload() {
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(false);
-    
+
     const files = Array.from(e.dataTransfer.files);
     if (files.length > 0) {
       handleFileSelect(files[0]);
@@ -83,6 +83,12 @@ export default function FitFileUpload() {
   };
 
   const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+    setIsDragOver(true);
+  };
+
+  const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(true);
   };
@@ -136,6 +142,7 @@ export default function FitFileUpload() {
                 : "border-gray-300 hover:border-ocean-blue"
             } ${uploadMutation.isPending ? "opacity-50 pointer-events-none" : ""}`}
             onDrop={handleDrop}
+            onDragEnter={handleDragEnter}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onClick={handleClick}

--- a/client/src/components/session-form.tsx
+++ b/client/src/components/session-form.tsx
@@ -42,10 +42,10 @@ export default function SessionForm() {
       sessionType: "Training",
       distance: 0,
       duration: 0,
-      heartRate: "",
-      strokeRate: "",
-      power: "",
-      perceivedEffort: "",
+      heartRate: undefined,
+      strokeRate: undefined,
+      power: undefined,
+      perceivedEffort: undefined,
       notes: "",
     },
   });
@@ -151,6 +151,7 @@ export default function SessionForm() {
                         step="0.1"
                         placeholder="8.4"
                         {...field}
+                        value={field.value ?? ""}
                         onChange={(e) => field.onChange(parseFloat(e.target.value) || 0)}
                       />
                     </FormControl>
@@ -180,6 +181,7 @@ export default function SessionForm() {
                         type="number"
                         placeholder="42"
                         {...field}
+                        value={field.value ?? ""}
                         onChange={(e) => field.onChange(parseInt(e.target.value) || 0)}
                       />
                     </FormControl>
@@ -211,7 +213,12 @@ export default function SessionForm() {
                         type="number"
                         placeholder="180"
                         {...field}
-                        onChange={(e) => field.onChange(e.target.value)}
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value ? parseInt(e.target.value) : undefined
+                          )
+                        }
                       />
                     </FormControl>
                     <FormMessage />
@@ -240,6 +247,7 @@ export default function SessionForm() {
                         type="number"
                         placeholder="68"
                         {...field}
+                        value={field.value ?? ""}
                         onChange={(e) => field.onChange(e.target.value ? parseInt(e.target.value) : undefined)}
                       />
                     </FormControl>
@@ -271,6 +279,7 @@ export default function SessionForm() {
                         type="number"
                         placeholder="250"
                         {...field}
+                        value={field.value ?? ""}
                         onChange={(e) => field.onChange(e.target.value ? parseInt(e.target.value) : undefined)}
                       />
                     </FormControl>
@@ -302,6 +311,7 @@ export default function SessionForm() {
                         max="10"
                         placeholder="7"
                         {...field}
+                        value={field.value ?? ""}
                         onChange={(e) => field.onChange(e.target.value ? parseInt(e.target.value) : undefined)}
                       />
                     </FormControl>
@@ -322,6 +332,7 @@ export default function SessionForm() {
                       placeholder="Good session, felt strong throughout. Worked on catch technique."
                       className="h-24"
                       {...field}
+                      value={field.value ?? ""}
                     />
                   </FormControl>
                   <FormMessage />

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -211,17 +211,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       // Parse the FIT file
       const fitData = await parseFitFile(req.file.buffer);
-      
+
       // Extract session data from FIT file
       const sessionData = extractSessionDataFromFit(fitData);
-      
+
       // Create session with FIT data
       const session = await storage.createSession(sessionData);
-      
+
       res.json(session);
-    } catch (error) {
+    } catch (error: any) {
       console.error('FIT file processing error:', error);
-      res.status(400).json({ error: "Failed to process FIT file" });
+      res.status(400).json({ error: error.message || "Failed to process FIT file" });
     }
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
+  "include": ["client/src/**/*", "shared/**/*", "server/**/*", "types/**/*"],
   "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
   "compilerOptions": {
     "incremental": true,

--- a/types/fit-file-parser.d.ts
+++ b/types/fit-file-parser.d.ts
@@ -1,0 +1,1 @@
+declare module 'fit-file-parser';


### PR DESCRIPTION
## Summary
- declare missing types for `fit-file-parser`
- include types folder in TS config
- default session form numeric values to undefined and coerce field values
- improve error reporting when FIT upload fails

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686c35c49d0c832ba19953db5ec0bb51