### PR TITLE
Add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# KayakTrackPro
+
+## Database Setup and Development Server
+
+1. **Configure `DATABASE_URL`**
+   - Create a `.env` file in the project root.
+   - Set `DATABASE_URL` to the connection string for your database. You can use
+     a local PostgreSQL instance or a Neon database URL.
+
+2. **Run migrations**
+   - Install dependencies with `npm install` if needed.
+   - Run `npm run db:push` to create tables and apply migrations.
+
+3. **Start the server**
+   - Use `npm run dev` to start the Express server with Vite in development mode.
+   - The app will connect using `DATABASE_URL` and serve on port `5000`.
+


### PR DESCRIPTION
## Summary
- add README with database and server setup steps

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686c4304fa3c832bac6c95c457609d9c