### PR TITLE
Adjust button colors to white

### DIFF
--- a/client/src/components/session-form.tsx
+++ b/client/src/components/session-form.tsx
@@ -350,7 +350,7 @@ export default function SessionForm() {
             <div className="flex space-x-4">
               <Button
                 type="submit"
-                className="flex-1 bg-ocean-blue hover:bg-deep-water"
+                className="flex-1 bg-white text-black hover:bg-gray-100"
                 disabled={createSessionMutation.isPending}
               >
                 {createSessionMutation.isPending ? "Saving..." : "Save Session"}

--- a/client/src/components/vo2-calculator.tsx
+++ b/client/src/components/vo2-calculator.tsx
@@ -139,7 +139,7 @@ export default function VO2Calculator() {
                   )}
                 />
                 
-                <Button type="submit" className="w-full bg-ocean-blue hover:bg-deep-water">
+                <Button type="submit" className="w-full bg-white text-black hover:bg-gray-100">
                   Calculate VO₂ Max
                 </Button>
               </form>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 :root {
-  --background: hsl(0, 100%, 50%);
+  --background: hsl(0, 0%, 100%);
   --foreground: hsl(20, 14.3%, 4.1%);
   --muted: hsl(60, 4.8%, 95.9%);
   --muted-foreground: hsl(25, 5.3%, 44.7%);
@@ -13,8 +13,8 @@
   --card-foreground: hsl(20, 14.3%, 4.1%);
   --border: hsl(20, 5.9%, 90%);
   --input: hsl(20, 5.9%, 90%);
-  --primary: hsl(207, 90%, 54%);
-  --primary-foreground: hsl(211, 100%, 99%);
+  --primary: hsl(0, 0%, 100%);
+  --primary-foreground: hsl(20, 14.3%, 4.1%);
   --secondary: hsl(60, 4.8%, 95.9%);
   --secondary-foreground: hsl(24, 9.8%, 10%);
   --accent: hsl(60, 4.8%, 95.9%);
@@ -43,8 +43,8 @@
   --card-foreground: hsl(0, 0%, 98%);
   --border: hsl(240, 3.7%, 15.9%);
   --input: hsl(240, 3.7%, 15.9%);
-  --primary: hsl(207, 90%, 54%);
-  --primary-foreground: hsl(211, 100%, 99%);
+  --primary: hsl(0, 0%, 100%);
+  --primary-foreground: hsl(240, 10%, 3.9%);
   --secondary: hsl(240, 3.7%, 15.9%);
   --secondary-foreground: hsl(0, 0%, 98%);
   --accent: hsl(240, 3.7%, 15.9%);

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -16,13 +16,13 @@ export default function Dashboard() {
       {/* Quick Actions */}
       <div className="mb-8">
         <div className="flex flex-col sm:flex-row gap-4 mb-6">
-          <Button className="flex-1 bg-ocean-blue text-white hover:bg-deep-water" asChild>
+          <Button className="flex-1 bg-white text-black hover:bg-gray-100" asChild>
             <Link href="/sessions">
               <Plus className="w-4 h-4 mr-2" />
               Log New Session
             </Link>
           </Button>
-          <Button variant="outline" className="flex-1 text-ocean-blue border-ocean-blue hover:bg-water-light" asChild>
+          <Button variant="outline" className="flex-1 text-black border-gray-300 bg-white hover:bg-gray-100" asChild>
             <Link href="/analytics">
               <BarChart3 className="w-4 h-4 mr-2" />
               View Analytics

--- a/client/src/pages/sessions.tsx
+++ b/client/src/pages/sessions.tsx
@@ -55,7 +55,7 @@ export default function Sessions() {
           <Calendar className="w-12 h-12 text-gray-400 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-gray-900 mb-2">No sessions logged yet</h3>
           <p className="text-gray-600 mb-4">Start tracking your kayaking sessions to see your progress</p>
-          <Button className="bg-ocean-blue hover:bg-deep-water">
+          <Button className="bg-white text-black hover:bg-gray-100">
             Log Your First Session
           </Button>
         </div>
@@ -157,7 +157,7 @@ export default function Sessions() {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="text-ocean-blue border-ocean-blue hover:bg-water-light"
+                  className="text-black border-gray-300 bg-white hover:bg-gray-100"
                   onClick={() => setSelectedSession(session)}
                 >
                   <BarChart3 className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- use white as the primary color to keep buttons light
- update session form and VO2 calculator buttons
- adjust dashboard and sessions page buttons

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686cebc970ec832b94cff63cf1a26af5