### PR TITLE
Add session editing and deletion

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -178,6 +178,44 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/sessions/:id", async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const session = await storage.getSessionById(id);
+      if (!session) {
+        return res.status(404).json({ error: "Session not found" });
+      }
+      res.json(session);
+    } catch {
+      res.status(500).json({ error: "Failed to fetch session" });
+    }
+  });
+
+  app.put("/api/sessions/:id", async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const sessionData = insertSessionSchema.parse({
+        ...req.body,
+        date: new Date(req.body.date),
+      });
+      const updated = await storage.updateSession(id, sessionData);
+      res.json(updated);
+    } catch (error) {
+      console.error("PUT /api/sessions/:id", error);
+      res.status(400).json({ error: "Invalid session data" });
+    }
+  });
+
+  app.delete("/api/sessions/:id", async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      await storage.deleteSession(id);
+      res.json({ success: true });
+    } catch {
+      res.status(500).json({ error: "Failed to delete session" });
+    }
+  });
+
   app.get("/api/sessions/recent", async (req, res) => {
     try {
       const limit = parseInt(req.query.limit as string) || 10;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -7,6 +7,8 @@ export interface IStorage {
   createSession(session: InsertSession): Promise<Session>;
   getAllSessions(): Promise<Session[]>;
   getSessionById(id: number): Promise<Session | undefined>;
+  updateSession(id: number, session: InsertSession): Promise<Session>;
+  deleteSession(id: number): Promise<void>;
   getRecentSessions(limit: number): Promise<Session[]>;
   getSessionsByDateRange(startDate: Date, endDate: Date): Promise<Session[]>;
   
@@ -37,6 +39,19 @@ export class DatabaseStorage implements IStorage {
       .from(sessions)
       .where(eq(sessions.id, id));
     return session || undefined;
+  }
+
+  async updateSession(id: number, update: InsertSession): Promise<Session> {
+    const [session] = await db
+      .update(sessions)
+      .set(update)
+      .where(eq(sessions.id, id))
+      .returning();
+    return session;
+  }
+
+  async deleteSession(id: number): Promise<void> {
+    await db.delete(sessions).where(eq(sessions.id, id));
   }
 
   async getRecentSessions(limit: number): Promise<Session[]> {


### PR DESCRIPTION
## Summary
- add update and delete APIs on the server
- allow editing sessions and cancelling via SessionForm
- implement delete button with confirm and editing dialog on sessions page
- add filtering, sorting and summary info for sessions

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686cfd213bf4832b8f2823510af52f90