### PR TITLE
Add session search and refine logo style

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat+Alternates:wght@200;300;400;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import Dashboard from "@/pages/dashboard";
 import Sessions from "@/pages/sessions";
 import Analytics from "@/pages/analytics";
+import Login from "@/pages/login";
 import Navigation from "@/components/navigation";
 import MobileNav from "@/components/mobile-nav";
 import NotFound from "@/pages/not-found";
@@ -19,6 +20,7 @@ function Router() {
           <Route path="/" component={Dashboard} />
           <Route path="/sessions" component={Sessions} />
           <Route path="/analytics" component={Analytics} />
+          <Route path="/login" component={Login} />
           <Route component={NotFound} />
         </Switch>
       </main>

--- a/client/src/components/logo.tsx
+++ b/client/src/components/logo.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+interface LogoProps {
+  className?: string;
+}
+
+export default function Logo({ className }: LogoProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 300 80"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Kayax Logo"
+    >
+      <defs>
+        <linearGradient id="kayaxGradient" x1="0%" x2="100%" y1="0%" y2="0%">
+          <stop offset="0%" stop-color="#1769D7" />
+          <stop offset="25%" stop-color="#3A86E8" />
+          <stop offset="50%" stop-color="#6E7F97" />
+          <stop offset="75%" stop-color="#7A6F66" />
+          <stop offset="100%" stop-color="#A86A38" />
+        </linearGradient>
+      </defs>
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        fontFamily="'Montserrat Alternates', sans-serif"
+        fontWeight="200"
+        fontSize="56"
+        letterSpacing="4"
+        fill="url(#kayaxGradient)"
+        style={{ filter: "drop-shadow(0 2px 4px rgba(0,0,0,0.2))" }}
+      >
+        <tspan style={{ transform: "skewX(-10deg)", display: "inline-block" }}>
+          K
+        </tspan>
+        AYAX
+      </text>
+    </svg>
+  );
+}

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "wouter";
-import { Waves } from "lucide-react";
+import Logo from "./logo";
 
 export default function Navigation() {
   const [location] = useLocation();
@@ -14,9 +14,8 @@ export default function Navigation() {
     <header className="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
-          <Link href="/" className="flex items-center space-x-3">
-            <Waves className="text-ocean-blue text-2xl" />
-            <h1 className="text-xl font-bold text-gray-900">PaddleTracker</h1>
+          <Link href="/" className="flex items-center">
+            <Logo className="h-8 w-auto" />
           </Link>
           <nav className="hidden md:flex space-x-6">
             {navItems.map((item) => (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -25,7 +25,8 @@
   --radius: 0.5rem;
   
   /* Custom kayak app colors */
-  --ocean-blue: hsl(207, 90%, 54%);
+  --ocean-blue: #1769D7;
+  --copper: #A86A38;
   --deep-water: hsl(211, 100%, 27%);
   --bright-cyan: hsl(192, 100%, 40%);
   --water-light: hsl(192, 100%, 93%);
@@ -53,6 +54,7 @@
   --destructive-foreground: hsl(0, 0%, 98%);
   --ring: hsl(240, 4.9%, 83.9%);
   --radius: 0.5rem;
+  --copper: #A86A38;
 }
 
 @layer base {
@@ -81,6 +83,10 @@
   .text-paddle-orange {
     color: var(--paddle-orange);
   }
+
+  .text-copper {
+    color: var(--copper);
+  }
   
   .bg-ocean-blue {
     background-color: var(--ocean-blue);
@@ -97,9 +103,17 @@
   .bg-paddle-orange {
     background-color: var(--paddle-orange);
   }
+
+  .bg-copper {
+    background-color: var(--copper);
+  }
   
   .border-ocean-blue {
     border-color: var(--ocean-blue);
+  }
+
+  .border-copper {
+    border-color: var(--copper);
   }
   
   .hover\:bg-deep-water:hover {

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,0 +1,23 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import Logo from "@/components/logo";
+
+export default function Login() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-white px-4">
+      <Logo className="w-56 mb-8" />
+      <div className="w-full max-w-sm space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" type="email" placeholder="you@example.com" />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input id="password" type="password" />
+        </div>
+        <Button className="w-full">Login</Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/sessions.tsx
+++ b/client/src/pages/sessions.tsx
@@ -1,18 +1,68 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Calendar, Clock, Heart, Zap, Power, BarChart3 } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Calendar, Clock, Heart, Zap, Power, BarChart3, Pencil, Trash2 } from "lucide-react";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import SessionForm from "@/components/session-form";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
 import { format } from "date-fns";
 import SessionDetails from "@/components/session-details";
 import type { Session } from "@shared/schema";
 
 export default function Sessions() {
   const [selectedSession, setSelectedSession] = useState<Session | null>(null);
+  const [editingSession, setEditingSession] = useState<Session | null>(null);
+  const [filterType, setFilterType] = useState<string>("All");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  const [search, setSearch] = useState("");
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
   
   const { data: sessions, isLoading } = useQuery<Session[]>({
     queryKey: ["/api/sessions"],
+  });
+
+  const filteredSessions = (sessions || [])
+    .filter((s) => filterType === "All" || s.sessionType === filterType)
+    .filter((s) =>
+      search
+        ? (s.notes || "").toLowerCase().includes(search.toLowerCase()) ||
+          s.sessionType.toLowerCase().includes(search.toLowerCase())
+        : true
+    )
+    .slice()
+    .sort((a, b) =>
+      sortDir === "asc"
+        ? new Date(a.date).getTime() - new Date(b.date).getTime()
+        : new Date(b.date).getTime() - new Date(a.date).getTime()
+    );
+
+  const summary = filteredSessions.reduce(
+    (acc, s) => {
+      acc.distance += s.distance;
+      acc.duration += s.duration;
+      return acc;
+    },
+    { distance: 0, duration: 0 }
+  );
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => {
+      await apiRequest("DELETE", `/api/sessions/${id}`);
+    },
+    onSuccess: () => {
+      toast({ title: "Session deleted" });
+      queryClient.invalidateQueries({ queryKey: ["/api/sessions"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/sessions/recent"] });
+    },
+    onError: () => {
+      toast({ title: "Failed to delete", variant: "destructive" });
+    },
   });
 
   const formatDuration = (minutes: number) => {
@@ -70,8 +120,43 @@ export default function Sessions() {
         <p className="text-gray-600">Track your progress and analyze your performance</p>
       </div>
 
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6 gap-4">
+        <div className="flex space-x-4">
+          <Select value={filterType} onValueChange={setFilterType}>
+            <SelectTrigger className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="All">All</SelectItem>
+              <SelectItem value="Training">Training</SelectItem>
+              <SelectItem value="Race">Race</SelectItem>
+              <SelectItem value="Recovery">Recovery</SelectItem>
+              <SelectItem value="Technique">Technique</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={sortDir} onValueChange={(v) => setSortDir(v as "asc" | "desc") }>
+            <SelectTrigger className="w-28">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="desc">Newest</SelectItem>
+              <SelectItem value="asc">Oldest</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            placeholder="Search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-40"
+          />
+        </div>
+        <div className="bg-gray-50 rounded-lg px-4 py-2 text-sm text-gray-600">
+          {filteredSessions.length} sessions &bull; {summary.distance.toFixed(1)} km &bull; {summary.duration} min
+        </div>
+      </div>
+
       <div className="space-y-4">
-        {sessions.map((session) => (
+        {filteredSessions.map((session) => (
           <Card key={session.id} className="hover:shadow-md transition-shadow">
             <CardHeader className="pb-3">
               <div className="flex justify-between items-start">
@@ -82,9 +167,25 @@ export default function Sessions() {
                     {format(new Date(session.date), "MMM dd, yyyy")}
                   </div>
                 </div>
-                <Badge className={getSessionTypeColor(session.sessionType)}>
-                  {session.sessionType}
-                </Badge>
+                <div className="flex items-center space-x-2">
+                  <Badge className={getSessionTypeColor(session.sessionType)}>
+                    {session.sessionType}
+                  </Badge>
+                  <Button variant="ghost" size="icon" onClick={() => setEditingSession(session)}>
+                    <Pencil className="w-4 h-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => {
+                      if (confirm("Delete this session?")) {
+                        deleteMutation.mutate(session.id);
+                      }
+                    }}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                </div>
               </div>
             </CardHeader>
             <CardContent>
@@ -175,6 +276,18 @@ export default function Sessions() {
           session={selectedSession}
           onClose={() => setSelectedSession(null)}
         />
+      )}
+
+      {editingSession && (
+        <Dialog open onOpenChange={() => setEditingSession(null)}>
+          <DialogContent>
+            <SessionForm
+              session={editingSession}
+              onSuccess={() => setEditingSession(null)}
+              onCancel={() => setEditingSession(null)}
+            />
+          </DialogContent>
+        </Dialog>
       )}
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "@neondatabase/serverless": "^0.10.4",
         "@radix-ui/react-accordion": "^1.2.4",
         "@radix-ui/react-alert-dialog": "^1.1.7",
         "@radix-ui/react-aspect-ratio": "^1.1.3",
@@ -1389,6 +1388,8 @@
       "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.10.4.tgz",
       "integrity": "sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/pg": "8.11.6"
       }
@@ -3524,6 +3525,7 @@
       "version": "8.11.6",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
       "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -6477,6 +6479,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -6653,6 +6656,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
       "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=4"
@@ -6677,6 +6681,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
       "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -6938,6 +6943,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
       "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6947,6 +6953,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
       "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "obuf": "~1.1.2"
@@ -6959,6 +6966,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
       "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6968,6 +6976,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
       "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6977,6 +6986,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/prop-types": {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -178,6 +178,44 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/sessions/:id", async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const session = await storage.getSessionById(id);
+      if (!session) {
+        return res.status(404).json({ error: "Session not found" });
+      }
+      res.json(session);
+    } catch {
+      res.status(500).json({ error: "Failed to fetch session" });
+    }
+  });
+
+  app.put("/api/sessions/:id", async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const sessionData = insertSessionSchema.parse({
+        ...req.body,
+        date: new Date(req.body.date),
+      });
+      const updated = await storage.updateSession(id, sessionData);
+      res.json(updated);
+    } catch (error) {
+      console.error("PUT /api/sessions/:id", error);
+      res.status(400).json({ error: "Invalid session data" });
+    }
+  });
+
+  app.delete("/api/sessions/:id", async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      await storage.deleteSession(id);
+      res.json({ success: true });
+    } catch {
+      res.status(500).json({ error: "Failed to delete session" });
+    }
+  });
+
   app.get("/api/sessions/recent", async (req, res) => {
     try {
       const limit = parseInt(req.query.limit as string) || 10;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -7,6 +7,8 @@ export interface IStorage {
   createSession(session: InsertSession): Promise<Session>;
   getAllSessions(): Promise<Session[]>;
   getSessionById(id: number): Promise<Session | undefined>;
+  updateSession(id: number, session: InsertSession): Promise<Session>;
+  deleteSession(id: number): Promise<void>;
   getRecentSessions(limit: number): Promise<Session[]>;
   getSessionsByDateRange(startDate: Date, endDate: Date): Promise<Session[]>;
   
@@ -37,6 +39,19 @@ export class DatabaseStorage implements IStorage {
       .from(sessions)
       .where(eq(sessions.id, id));
     return session || undefined;
+  }
+
+  async updateSession(id: number, update: InsertSession): Promise<Session> {
+    const [session] = await db
+      .update(sessions)
+      .set(update)
+      .where(eq(sessions.id, id))
+      .returning();
+    return session;
+  }
+
+  async deleteSession(id: number): Promise<void> {
+    await db.delete(sessions).where(eq(sessions.id, id));
   }
 
   async getRecentSessions(limit: number): Promise<Session[]> {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,9 @@ export default {
   content: ["./client/index.html", "./client/src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ["Montserrat Alternates", "sans-serif"],
+      },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",


### PR DESCRIPTION
## Summary
- use Montserrat Alternates font for crossbarless "A" style
- restore blue as primary color and introduce copper secondary
- lighten the logo letters and remove the lambda glyphs
- allow searching sessions by notes or type

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686cfd213bf4832b8f2823510af52f90