### PR TITLE
Add analytics charts

### DIFF
--- a/client/src/components/speed-heart-rate-chart.tsx
+++ b/client/src/components/speed-heart-rate-chart.tsx
@@ -1,0 +1,79 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Activity, Heart } from "lucide-react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from "recharts";
+import type { Session } from "@shared/schema";
+import * as React from "react";
+
+export default function SpeedHeartRateChart() {
+  const { data: sessions } = useQuery<Session[]>({
+    queryKey: ["/api/sessions"],
+  });
+
+  const data = React.useMemo(() => {
+    if (!sessions) return [] as { date: string; speed: number; heartRate: number | null }[];
+    return sessions
+      .slice()
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+      .map((s) => {
+        const speed = s.avgSpeed || (s.distance && s.duration ? s.distance / (s.duration / 60) : 0);
+        return {
+          date: new Date(s.date).toLocaleDateString(),
+          speed: Number(speed.toFixed(1)),
+          heartRate: s.heartRate || null,
+        };
+      });
+  }, [sessions]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center">
+          <Activity className="w-4 h-4 mr-2 text-ocean-blue" />
+          Speed & Heart Rate Trend
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <div className="text-center py-8 text-gray-600">
+            Log sessions to view speed and heart rate trends
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" />
+              <YAxis yAxisId="left" />
+              <YAxis yAxisId="right" orientation="right" />
+              <Tooltip />
+              <Line
+                yAxisId="left"
+                type="monotone"
+                dataKey="speed"
+                name="Speed (km/h)"
+                stroke="#0ea5e9"
+                strokeWidth={2}
+              />
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="heartRate"
+                name="Heart Rate (bpm)"
+                stroke="#ef4444"
+                strokeWidth={2}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/weekly-distance-chart.tsx
+++ b/client/src/components/weekly-distance-chart.tsx
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { TrendingUp } from "lucide-react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from "recharts";
+import type { Session } from "@shared/schema";
+import * as React from "react";
+
+export default function WeeklyDistanceChart() {
+  const { data: sessions } = useQuery<Session[]>({
+    queryKey: ["/api/sessions"],
+  });
+
+  const data = React.useMemo(() => {
+    if (!sessions) return [] as { week: string; distance: number }[];
+    const map = new Map<string, number>();
+    sessions.forEach((s) => {
+      const date = new Date(s.date);
+      const weekStart = new Date(
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate() - date.getDay()
+      );
+      const key = weekStart.toISOString().slice(0, 10);
+      map.set(key, (map.get(key) || 0) + s.distance);
+    });
+    return Array.from(map.entries())
+      .sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime())
+      .map(([week, distance]) => ({ week, distance: Number(distance.toFixed(1)) }));
+  }, [sessions]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center">
+          <TrendingUp className="w-4 h-4 mr-2 text-ocean-blue" />
+          Weekly Distance
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <div className="text-center py-8 text-gray-600">
+            Log sessions to see distance trends
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="week" />
+              <YAxis />
+              <Tooltip formatter={(v) => [`${v} km`, "Distance"]} />
+              <Line
+                type="monotone"
+                dataKey="distance"
+                stroke="hsl(207, 90%, 54%)"
+                strokeWidth={2}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/analytics.tsx
+++ b/client/src/pages/analytics.tsx
@@ -1,5 +1,9 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { TrendingUp, Target, Award, Activity } from "lucide-react";
+import WeeklyDistanceChart from "@/components/weekly-distance-chart";
+import SpeedHeartRateChart from "@/components/speed-heart-rate-chart";
+import TrainingZones from "@/components/training-zones";
+import PerformanceInsights from "@/components/performance-insights";
 
 export default function Analytics() {
   return (
@@ -63,10 +67,14 @@ export default function Analytics() {
         </Card>
       </div>
 
-      <div className="text-center py-12">
-        <Activity className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-        <h3 className="text-lg font-medium text-gray-900 mb-2">Advanced Analytics Coming Soon</h3>
-        <p className="text-gray-600">Detailed performance charts and trends will be available here</p>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+        <WeeklyDistanceChart />
+        <SpeedHeartRateChart />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <TrainingZones />
+        <PerformanceInsights />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add new WeeklyDistanceChart and SpeedHeartRateChart components
- show new charts on analytics page alongside training tools

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686d09eabcb4832baef85e518ee3d725