### PR TITLE
Add today session reminder and unify fonts

### DIFF
--- a/client/src/components/today-sessions.tsx
+++ b/client/src/components/today-sessions.tsx
@@ -1,0 +1,87 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "lucide-react";
+import { Link } from "wouter";
+import { format, isToday } from "date-fns";
+import type { Session } from "@shared/schema";
+
+export default function TodaySessions() {
+  const { data: sessions, isLoading } = useQuery<Session[]>({
+    queryKey: ["/api/sessions"],
+  });
+
+  const todaysSessions = (sessions || []).filter((s) =>
+    isToday(new Date(s.date))
+  );
+
+  if (isLoading) {
+    return (
+      <Card className="mb-8">
+        <CardContent className="space-y-2 py-6">
+          <div className="h-4 bg-gray-200 rounded w-3/4" />
+          <div className="h-3 bg-gray-200 rounded w-1/2" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (todaysSessions.length === 0) {
+    return (
+      <Card className="mb-8">
+        <CardContent className="text-center py-6">
+          <Calendar className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+          <p className="text-gray-700 mb-4">
+            You haven't logged a session today
+          </p>
+          <Button
+            asChild
+            className="bg-white text-black hover:bg-gray-100 border border-gray-300"
+          >
+            <Link href="/sessions">Log Today's Session</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="mb-8">
+      <CardHeader>
+        <CardTitle className="flex items-center">
+          <Calendar className="w-5 h-5 text-ocean-blue mr-2" />
+          Today's Training
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {todaysSessions.map((session) => (
+            <div
+              key={session.id}
+              className="p-4 bg-gray-50 rounded-lg border border-gray-200"
+            >
+              <div className="flex justify-between items-start mb-2">
+                <div>
+                  <div className="font-medium text-gray-900">
+                    {session.sessionType}
+                  </div>
+                  <div className="text-sm text-gray-600">
+                    {format(new Date(session.date), "p")}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-sm font-medium text-ocean-blue">
+                    {session.distance} km
+                  </div>
+                  <div className="text-xs text-gray-500">
+                    {session.duration} min
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -3,6 +3,7 @@ import { Plus, BarChart3 } from "lucide-react";
 import { Link } from "wouter";
 import Logo from "@/components/logo";
 import PerformanceOverview from "@/components/performance-overview";
+import TodaySessions from "@/components/today-sessions";
 import SessionForm from "@/components/session-form";
 import FitFileUpload from "@/components/fit-file-upload";
 import RecentSessions from "@/components/recent-sessions";
@@ -34,6 +35,9 @@ export default function Dashboard() {
           </Button>
         </div>
       </div>
+
+      {/* Today's Session Reminder */}
+      <TodaySessions />
 
       {/* Performance Overview */}
       <PerformanceOverview />


### PR DESCRIPTION
## Summary
- remind users on Dashboard page if today's session hasn't been logged yet
- show today's sessions once a session is logged
- include Montserrat font only so logo appearance stays consistent
- ensure reminder checks sessions using date-fns `isToday`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686d15656d98832b8e2660169d5c0138