### PR TITLE
Round distances to two decimals

### DIFF
--- a/client/src/components/fit-file-upload.tsx
+++ b/client/src/components/fit-file-upload.tsx
@@ -38,10 +38,10 @@ export default function FitFileUpload() {
       return response.json();
     },
     onSuccess: (data) => {
-      toast({
-        title: "FIT File Uploaded Successfully!",
-        description: `Your Garmin session has been imported with ${data.distance}km distance and ${data.duration} minutes duration.`,
-      });
+        toast({
+          title: "FIT File Uploaded Successfully!",
+          description: `Your Garmin session has been imported with ${data.distance.toFixed(2)}km distance and ${data.duration} minutes duration.`,
+        });
       
       // Reset progress after a short delay
       setTimeout(() => setUploadProgress(0), 1000);

--- a/client/src/components/recent-sessions.tsx
+++ b/client/src/components/recent-sessions.tsx
@@ -64,7 +64,7 @@ export default function RecentSessions() {
                     </div>
                   </div>
                   <div className="text-right">
-                    <div className="text-sm font-medium text-ocean-blue">{session.distance} km</div>
+                      <div className="text-sm font-medium text-ocean-blue">{session.distance.toFixed(2)} km</div>
                     <div className="text-xs text-gray-500">{session.duration} min</div>
                   </div>
                 </div>

--- a/client/src/components/session-details.tsx
+++ b/client/src/components/session-details.tsx
@@ -99,7 +99,7 @@ export default function SessionDetails({ session, onClose }: SessionDetailsProps
           {/* Session Summary */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
             <div className="bg-gray-50 p-4 rounded-lg">
-              <div className="text-2xl font-bold text-ocean-blue">{session.distance} km</div>
+                <div className="text-2xl font-bold text-ocean-blue">{session.distance.toFixed(2)} km</div>
               <div className="text-sm text-gray-600">Distance</div>
             </div>
             <div className="bg-gray-50 p-4 rounded-lg">

--- a/client/src/components/today-sessions.tsx
+++ b/client/src/components/today-sessions.tsx
@@ -87,9 +87,9 @@ export default function TodaySessions() {
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-sm font-medium text-ocean-blue">
-                    {session.distance} km
-                  </div>
+                    <div className="text-sm font-medium text-ocean-blue">
+                      {session.distance.toFixed(2)} km
+                    </div>
                   <div className="text-xs text-gray-500">
                     {session.duration} min
                   </div>

--- a/client/src/pages/fitness-stats.tsx
+++ b/client/src/pages/fitness-stats.tsx
@@ -45,6 +45,14 @@ export default function FitnessStats() {
   const currentDistance = distances[index];
   const prediction = predictions ? predictions[currentDistance] : null;
 
+  const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (e.deltaY > 10) {
+      cycle(1);
+    } else if (e.deltaY < -10) {
+      cycle(-1);
+    }
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="mb-6">
@@ -81,7 +89,10 @@ export default function FitnessStats() {
                 >
                   <ChevronRight className="w-4 h-4" />
                 </Button>
-                <div className="relative overflow-hidden h-[4.5rem] flex flex-col items-center justify-center">
+                <div
+                  onWheel={handleWheel}
+                  className="relative overflow-hidden h-[4.5rem] flex flex-col items-center justify-center"
+                >
                   <div className="relative">
                     <AnimatePresence custom={direction} mode="wait" initial={false}>
                       <motion.div

--- a/client/src/pages/sessions.tsx
+++ b/client/src/pages/sessions.tsx
@@ -154,7 +154,7 @@ export default function Sessions() {
 
         </div>
         <div className="bg-gray-50 rounded-lg px-4 py-2 text-sm text-gray-600">
-          {filteredSessions.length} sessions &bull; {summary.distance.toFixed(1)} km &bull; {summary.duration} min
+          {filteredSessions.length} sessions &bull; {summary.distance.toFixed(2)} km &bull; {summary.duration} min
         </div>
       </div>
 
@@ -198,7 +198,7 @@ export default function Sessions() {
                     <span className="text-white text-sm font-medium">📏</span>
                   </div>
                   <div>
-                    <div className="text-sm font-medium text-ocean-blue">{session.distance} km</div>
+                    <div className="text-sm font-medium text-ocean-blue">{session.distance.toFixed(2)} km</div>
                     <div className="text-xs text-gray-500">Distance</div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- display session distance values rounded to two decimals
- include two-decimal distances in FIT upload notifications
- enable scroll-based slide animation for race time predictions

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686d21aba4d0832b8147024774139cf8