### PR TITLE
Add time entry dialog with race and training forms

### DIFF
--- a/client/src/components/race-results.tsx
+++ b/client/src/components/race-results.tsx
@@ -30,18 +30,24 @@ import {
 interface RaceResult {
   id: number;
   name: string;
-  wind: string;
+  wind: number;
   location: string;
   distance: number;
   time: string;
+  note?: string;
+  maxHeartRate: number;
+  maxSpeed: number;
 }
 
 const formSchema = z.object({
   name: z.string().min(1, "Required"),
-  wind: z.string().min(1, "Required"),
+  wind: z.number().min(0, "Required"),
   location: z.string().min(1, "Required"),
   distance: z.number().min(0.1, "Distance must be positive"),
   time: z.string().min(1, "Required"),
+  note: z.string().optional(),
+  maxHeartRate: z.number().min(0, "Required"),
+  maxSpeed: z.number().min(0, "Required"),
 });
 
 type FormData = z.infer<typeof formSchema>;
@@ -53,10 +59,13 @@ export default function RaceResults() {
     resolver: zodResolver(formSchema),
     defaultValues: {
       name: "",
-      wind: "",
+      wind: 0,
       location: "",
       distance: 200,
       time: "",
+      note: "",
+      maxHeartRate: 0,
+      maxSpeed: 0,
     },
   });
 
@@ -81,7 +90,16 @@ export default function RaceResults() {
       ...data,
     };
     setResults([...results, newResult]);
-    form.reset();
+    form.reset({
+      name: "",
+      wind: 0,
+      location: "",
+      distance: 200,
+      time: "",
+      note: "",
+      maxHeartRate: 0,
+      maxSpeed: 0,
+    });
   };
 
   return (
@@ -111,9 +129,14 @@ export default function RaceResults() {
                 name="wind"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Wind Strength</FormLabel>
+                    <FormLabel>Wind Strength (km/h)</FormLabel>
                     <FormControl>
-                      <Input placeholder="3 m/s tailwind" {...field} />
+                      <Input
+                        type="number"
+                        {...field}
+                        value={field.value}
+                        onChange={(e) => field.onChange(parseInt(e.target.value) || 0)}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -166,7 +189,57 @@ export default function RaceResults() {
                   </FormItem>
                 )}
               />
+              <FormField
+                control={form.control}
+                name="maxHeartRate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Max Heart Rate (bpm)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        {...field}
+                        value={field.value}
+                        onChange={(e) => field.onChange(parseInt(e.target.value) || 0)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="maxSpeed"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Max Speed (km/h)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.1"
+                        {...field}
+                        value={field.value}
+                        onChange={(e) => field.onChange(parseFloat(e.target.value) || 0)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </div>
+            <FormField
+              control={form.control}
+              name="note"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Megjegyzés / Érzés</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
             <Button
               type="submit"
               className="bg-white text-black border border-gray-300 hover:bg-gray-100"
@@ -182,10 +255,13 @@ export default function RaceResults() {
               <TableHeader>
                 <TableRow>
                   <TableHead>Race</TableHead>
-                  <TableHead>Wind</TableHead>
+                  <TableHead>Wind (km/h)</TableHead>
                   <TableHead>Location</TableHead>
                   <TableHead className="text-right">Distance (m)</TableHead>
                   <TableHead className="text-right">Time</TableHead>
+                  <TableHead className="text-right">Max HR</TableHead>
+                  <TableHead className="text-right">Max Speed</TableHead>
+                  <TableHead>Note</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -198,6 +274,9 @@ export default function RaceResults() {
                       {result.distance}
                     </TableCell>
                     <TableCell className="text-right">{result.time}</TableCell>
+                    <TableCell className="text-right">{result.maxHeartRate}</TableCell>
+                    <TableCell className="text-right">{result.maxSpeed}</TableCell>
+                    <TableCell>{result.note}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/client/src/components/time-entry-dialog.tsx
+++ b/client/src/components/time-entry-dialog.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import RaceResults from "@/components/race-results";
+import TrainingEntries from "@/components/training-entries";
+
+export default function TimeEntryDialog() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button className="bg-white text-black border border-gray-300 hover:bg-gray-100" onClick={() => setOpen(true)}>
+        Idő bevitele
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Idő bevitele</DialogTitle>
+          </DialogHeader>
+          <Tabs defaultValue="race" className="mt-4">
+            <TabsList>
+              <TabsTrigger value="race">Verseny</TabsTrigger>
+              <TabsTrigger value="training">Edzés</TabsTrigger>
+            </TabsList>
+            <TabsContent value="race">
+              <RaceResults />
+            </TabsContent>
+            <TabsContent value="training">
+              <TrainingEntries />
+            </TabsContent>
+          </Tabs>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/client/src/components/training-entries.tsx
+++ b/client/src/components/training-entries.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+interface TrainingEntry {
+  id: number;
+  trackLength: number;
+  trackTime: string;
+  maxHeartRate: number;
+  maxSpeed: number;
+  state: string;
+  note?: string;
+}
+
+const states = [
+  "edzetlen",
+  "nagyon kipihent",
+  "kipihent",
+  "semleges",
+  "fáradt",
+  "agyon fáradt",
+];
+
+const formSchema = z.object({
+  trackLength: z.number().min(1, "Required"),
+  trackTime: z.string().min(1, "Required"),
+  maxHeartRate: z.number().min(0, "Required"),
+  maxSpeed: z.number().min(0, "Required"),
+  state: z.string().min(1, "Required"),
+  note: z.string().optional(),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+export default function TrainingEntries() {
+  const [entries, setEntries] = useState<TrainingEntry[]>([]);
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      trackLength: 1000,
+      trackTime: "",
+      maxHeartRate: 0,
+      maxSpeed: 0,
+      state: "semleges",
+      note: "",
+    },
+  });
+
+  useEffect(() => {
+    const stored = localStorage.getItem("trainingEntries");
+    if (stored) {
+      try {
+        setEntries(JSON.parse(stored));
+      } catch {
+        // ignore
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("trainingEntries", JSON.stringify(entries));
+  }, [entries]);
+
+  const onSubmit = (data: FormData) => {
+    const entry: TrainingEntry = {
+      id: Date.now(),
+      ...data,
+    };
+    setEntries([...entries, entry]);
+    form.reset({
+      trackLength: 1000,
+      trackTime: "",
+      maxHeartRate: 0,
+      maxSpeed: 0,
+      state: "semleges",
+      note: "",
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Edzés</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="trackLength"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Pálya hossza (m)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        {...field}
+                        value={field.value}
+                        onChange={(e) => field.onChange(parseFloat(e.target.value) || 0)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="trackTime"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Pálya ideje</FormLabel>
+                    <FormControl>
+                      <Input placeholder="1:45" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="maxHeartRate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Max pulzus (bpm)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        {...field}
+                        value={field.value}
+                        onChange={(e) => field.onChange(parseInt(e.target.value) || 0)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="maxSpeed"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Max sebesség (km/h)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.1"
+                        {...field}
+                        value={field.value}
+                        onChange={(e) => field.onChange(parseFloat(e.target.value) || 0)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="state"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Állapot</FormLabel>
+                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {states.map((s) => (
+                          <SelectItem key={s} value={s}>{s}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <FormField
+              control={form.control}
+              name="note"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Megjegyzés / Érzés</FormLabel>
+                  <FormControl>
+                    <Textarea {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button type="submit" className="bg-white text-black border border-gray-300 hover:bg-gray-100">
+              Hozzáadás
+            </Button>
+          </form>
+        </Form>
+        {entries.length > 0 && (
+          <div className="mt-6">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Pálya (m)</TableHead>
+                  <TableHead>Idő</TableHead>
+                  <TableHead>Max HR</TableHead>
+                  <TableHead>Max Seb.</TableHead>
+                  <TableHead>Állapot</TableHead>
+                  <TableHead>Megjegyzés</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {entries.map((e) => (
+                  <TableRow key={e.id}>
+                    <TableCell>{e.trackLength}</TableCell>
+                    <TableCell>{e.trackTime}</TableCell>
+                    <TableCell>{e.maxHeartRate}</TableCell>
+                    <TableCell>{e.maxSpeed}</TableCell>
+                    <TableCell>{e.state}</TableCell>
+                    <TableCell>{e.note}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -8,6 +8,7 @@ import SessionForm from "@/components/session-form";
 import FitFileUpload from "@/components/fit-file-upload";
 import RecentSessions from "@/components/recent-sessions";
 import RacePredictions from "@/components/race-predictions";
+import TimeEntryDialog from "@/components/time-entry-dialog";
 import TrainingZones from "@/components/training-zones";
 import PerformanceInsights from "@/components/performance-insights";
 import VO2Calculator from "@/components/vo2-calculator";
@@ -33,6 +34,7 @@ export default function Dashboard() {
               View Analytics
             </Link>
           </Button>
+          <TimeEntryDialog />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add dialog for time entry with tabs for race and training
- extend race results form with note, max heart rate and max speed inputs
- store wind strength in km/h
- implement local storage form for training entries with state selector
- expose time entry dialog on dashboard

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686d38b101f8832b8ce057b4f60af83b