### PR TITLE
Add weekly EPOC chart

### DIFF
--- a/client/src/components/weekly-epoc-chart.tsx
+++ b/client/src/components/weekly-epoc-chart.tsx
@@ -1,0 +1,91 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { HeartPulse } from "lucide-react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from "recharts";
+import { estimateEpoc } from "@/lib/kayak-calculations";
+import type { Session, UserSettings } from "@shared/schema";
+import * as React from "react";
+
+export default function WeeklyEpocChart() {
+  const { data: sessions } = useQuery<Session[]>({
+    queryKey: ["/api/sessions"],
+  });
+  const { data: settings } = useQuery<UserSettings | undefined>({
+    queryKey: ["/api/user-settings"],
+  });
+
+  const data = React.useMemo(() => {
+    if (!sessions || !settings) return [] as { week: string; epoc: number }[];
+    const map = new Map<string, number>();
+    sessions.forEach((s) => {
+      if (!s.powerData || !s.heartRateData) return;
+      try {
+        const power: number[] = JSON.parse(s.powerData);
+        const hr: number[] = JSON.parse(s.heartRateData);
+        if (power.length === 0 || hr.length === 0) return;
+        const pVo2max = Math.max(...power);
+        const result = estimateEpoc(
+          power,
+          hr,
+          pVo2max,
+          settings.restingHeartRate ?? 60,
+          settings.maxHeartRate ?? 190
+        );
+        const date = new Date(s.date);
+        const weekStart = new Date(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate() - date.getDay()
+        );
+        const key = weekStart.toISOString().slice(0, 10);
+        map.set(key, (map.get(key) || 0) + result.total);
+      } catch {
+        // ignore parsing errors
+      }
+    });
+    return Array.from(map.entries())
+      .sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime())
+      .map(([week, epoc]) => ({ week, epoc: Number(epoc.toFixed(1)) }));
+  }, [sessions, settings]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center">
+          <HeartPulse className="w-4 h-4 mr-2 text-ocean-blue" />
+          Weekly EPOC Load
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <div className="text-center py-8 text-gray-600">
+            Log sessions with power and heart rate data to see EPOC trends
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="week" />
+              <YAxis />
+              <Tooltip formatter={(v) => [`${v} ml/kg`, "EPOC"]} />
+              <Line
+                type="monotone"
+                dataKey="epoc"
+                stroke="hsl(207, 90%, 54%)"
+                strokeWidth={2}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/analytics.tsx
+++ b/client/src/pages/analytics.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { TrendingUp, Target, Award, Activity } from "lucide-react";
 import WeeklyDistanceChart from "@/components/weekly-distance-chart";
 import SpeedHeartRateChart from "@/components/speed-heart-rate-chart";
+import WeeklyEpocChart from "@/components/weekly-epoc-chart";
 import TrainingZones from "@/components/training-zones";
 import PerformanceInsights from "@/components/performance-insights";
 
@@ -70,6 +71,10 @@ export default function Analytics() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
         <WeeklyDistanceChart />
         <SpeedHeartRateChart />
+      </div>
+
+      <div className="mb-8">
+        <WeeklyEpocChart />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">

--- a/scripts/epoc.py
+++ b/scripts/epoc.py
@@ -1,0 +1,83 @@
+# EPOC estimation for kayaking training.
+# This script implements a simple model to estimate excess post-exercise
+# oxygen consumption (EPOC) based on power and heart rate data sampled
+# every 5 seconds.
+
+from typing import Iterable, Tuple, List
+
+
+def estimate_epoc(
+    power: Iterable[float],
+    hr: Iterable[float],
+    p_vo2max: float,
+    hr_rest: float,
+    hr_max: float,
+    k_down: float = 1.0,
+    k_up: float = 15.0,
+    n: float = 2.0,
+    beta: float = 0.05,
+    I0: float = 0.4,
+    dt: float = 5.0 / 60.0,
+) -> Tuple[float, List[float]]:
+    """Estimate EPOC over a workout.
+
+    Parameters
+    ----------
+    power : Iterable[float]
+        Sequence of power readings in Watts sampled every 5 seconds.
+    hr : Iterable[float]
+        Sequence of heart-rate readings in beats per minute sampled every
+        5 seconds.
+    p_vo2max : float
+        Power output at VO2max for the athlete in Watts.
+    hr_rest : float
+        Resting heart rate in beats per minute.
+    hr_max : float
+        Maximum heart rate in beats per minute.
+    k_down : float, optional
+        Recovery constant when intensity is below threshold.
+    k_up : float, optional
+        Accumulation constant when intensity is above threshold.
+    n : float, optional
+        Non-linearity exponent for intensity.
+    beta : float, optional
+        Saturation factor.
+    I0 : float, optional
+        Intensity threshold above which EPOC starts accumulating.
+    dt : float, optional
+        Time step in minutes. Default is 5 seconds -> 5/60 minutes.
+
+    Returns
+    -------
+    Tuple[float, List[float]]
+        Final EPOC value and the series of EPOC values for each step.
+    """
+    E = 0.0
+    series: List[float] = []
+
+    for p, h in zip(power, hr):
+        I_W = p / p_vo2max if p_vo2max else 0.0
+        denom = hr_max - hr_rest
+        I_HR = (h - hr_rest) / denom if denom else 0.0
+        I = max(I_W, I_HR)
+
+        if I <= I0:
+            dE = -k_down * E * dt
+        else:
+            dE = (k_up / (1.0 + beta * E)) * ((I - I0) ** n) * dt
+
+        E = max(0.0, E + dE)
+        series.append(E)
+
+    return E, series
+
+
+if __name__ == "__main__":
+    # Example usage with dummy data.
+    P = [100, 150, 200, 250, 300, 150, 100]
+    HR = [120, 130, 140, 160, 170, 150, 120]
+    epoc, epoc_series = estimate_epoc(
+        P, HR, p_vo2max=300, hr_rest=60, hr_max=180
+    )
+    print(f"Total EPOC: {epoc:.2f}")
+    print("Series:", epoc_series)


### PR DESCRIPTION
## Summary
- compute weekly EPOC load from session power and HR data
- display EPOC trend chart on the analytics page

## Testing
- `npm install`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687bef7fa7b8832bbe9b691da148f181